### PR TITLE
hotfix: v2.1.1 — limpiar marcadores de merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,11 +486,8 @@ ms-users/
 8. Cliente                ← 201 con datos del usuario creado
 ```
 
-<<<<<<< HEAD
 > El mismo flujo aplica al registro de institución, sustituyendo `crearCiudadano` por `crearInstitucion` y `repositories/ciudadano` por `repositories/institucion`.
 
-=======
->>>>>>> main
 ---
 
 ## Crear el primer superadmin (con Docker corriendo)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,4 @@ networks:
     driver: bridge
   sanos-y-salvos-net:
     external: true
-<<<<<<< HEAD
     name: ms_mascotas_sanos-y-salvos-net
-=======
->>>>>>> main

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ms-users",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ms-users",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-users",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Restaura README.md y docker-compose.yml tras marcadores de conflicto residuales del merge anterior. docker-compose.yml era inválido (YAML).